### PR TITLE
added chef-client::config to included recipes

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ryan.richard@rackspace.com'
 license          'All rights reserved'
 description      'Installs/Configures rackops-rolebook'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.5'
+version          '0.1.6'
 
 depends "rackspace-user"
 depends "motd"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,8 @@ include_recipe "sudo"
 
 include_recipe "chef-client"
 include_recipe "chef-client::delete_validation"
+include_recipe "chef-client::config"
+
 
 include_recipe "ntp"
 


### PR DESCRIPTION
I added the chef-client::config recipe which will add any config variables in node['chef_client']['config'] to the customers client.rb. This will let us fix the debian client_fork bomb issue through an env variable on Debian environments.
