### PR TITLE
Fixes #26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of rackops_rolebook.
 
+## 3.0.2
+* Fixes authorized_keys is recreated on every run
+  * ruby block pulls ssh keys from github repo, passes them as array to user_account resource called in ruby_block
+
 ## 3.0.1
 * Fix EDITOR environment variable in RHEL
 * Add strace to list of admin packages

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 rackops_rolebook Cookbook
 =========================
-This "rolebook" is a replacement for a traditional base role. It includes recipes like a role but is structured like a cookbook.
+This "rolebook" is a set of recipes that enable Rackspace to support DevOps Automation customers.  Should a customer no longer want Rackspace support, we are able to remove this "rolebook" without impacting any other automation the customer may be using.
 
 Requirements
 ------------
+- depends "apt"
 - depends "user"
 - depends "motd-tail"
 - depends "sudo"
 - depends "rackspace_iptables"
+- depends "ohai"
+- depends "platformstack"
 
 Attributes
 -----------
@@ -17,6 +20,9 @@ Recipes
 -------
 `default.rb` - This recipe includes all the recipes from the required core cookbooks. It will include chef-client recipes if we are *not* running in chef_solo mode. It adds the `rack` user to the sudo group and installs a bunch of handy applications.
 `acl.rb` - This recipe will the standard rackspace IPtables allows.
+`motd.rb` - This recipe sets the motd useful to Rackspace support.
+`public_info.rb` - This recipe sets a tag equal to the public IP detected on an external call.  This will assist Rackspace support in finding the correct IP to connect to via SSH
+`rack_user.rb` - This recipe sets up the rack user, and pulls in the authorized_keys file with the public keys of various Rackspace support staff so that support can access the server for troubleshooting and remediation.
 
 Usage
 -----
@@ -37,3 +43,4 @@ License and Authors
 -------------------
 Author: ryan.richard@rackspace.com
 Author: matt.thode@rackspace.com
+Author: jason.nelson@rackspace.com

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,8 +76,9 @@ Vagrant.configure("2") do |config|
   }
 
   chef.run_list = [
-      "recipe[rackspace_apt]",
-      "recipe[rackops_rolebook::default]"
+      "recipe[apt]",
+#      "recipe[rackops_rolebook::default]"
+      "recipe[rackops_rolebook::rack_user]"
   ]
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'All rights reserved'
 description      'Installs/Configures rackops_rolebook'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version          '3.0.1'
+version          '3.0.2'
 
 depends 'apt', '>= 2.4'
 depends 'motd-tail', '>= 2.0'

--- a/recipes/rack_user.rb
+++ b/recipes/rack_user.rb
@@ -12,16 +12,33 @@ node.set['authorization']['sudo']['include_sudoers_d'] = true
 include_recipe 'sudo'
 include_recipe 'user'
 
-user_account 'rack' do
-  comment   'Rackspace User'
-  home      '/home/rack'
+remote_file "#{Chef::Config[:file_cache_path]}/authorized_keys" do
+  source 'https://raw.github.com/rackops/authorized_keys/master/authorized_keys'
+  owner 'root'
+  group 'root'
+  mode 0644
+  use_conditional_get true
+  use_etag true
+  use_last_modified false
+  notifies :create, 'ruby_block[put_auth_keys_into_array]', :immediately
 end
 
-remote_file '/home/rack/.ssh/authorized_keys' do
-  source 'https://raw.github.com/rackops/authorized_keys/master/authorized_keys'
-  owner 'rack'
-  group 'rack'
-  mode 0644
+ruby_block 'put_auth_keys_into_array' do
+  block do
+    key_array = []
+    pattern = /^ssh-rsa/
+    File.readlines("#{Chef::Config[:file_cache_path]}/authorized_keys").each do |line|
+      if match = pattern.match(line)
+        key_array.push(line)
+      end
+    end
+    ua = Chef::Resource::UserAccount.new('rack', run_context)
+    ua.comment 'Rackspace User'
+    ua.home '/home/rack'
+    ua.ssh_keys key_array
+    ua.run_action :create
+  end
+  action :nothing
 end
 
 sudo 'rack' do


### PR DESCRIPTION
authorized_keys is no longer recreated between the user cookbook's template, and our remote_file call.  Instead our remote_file call populates an array that's passed to the user_account resource.
I have also updated README.md to reflect current status of rolebook.
