### PR TITLE
Since addition of platformstack dependency, kitchen converges fail

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,6 +22,13 @@ suites:
   run_list:
   - recipe[rackops_rolebook]
   attributes:
+    platformstack:
+      omnibus_updater:
+        enabled: false
+      cloud_monitoring:
+        enabled: false
+      cloud_backup:
+        enabled: false
     authorization:
       sudo:
         users:


### PR DESCRIPTION
Now that this depends on platformstack, it needs .kitchen.yml work to disable the 'service[chef-client]' resource, or it won't converge. We need to move this to chef-zero, add additional chef-solo guards like platformstack has, or use attributes to disable parts of platformstack that don't work with this kitchen, such as `node['platformstack']['omnibus_updater']['enabled']`.

I'm seeing that particular toggle not being set causing:

```
            Chef::Exceptions::ResourceNotFound
           ----------------------------------
           Cannot find a resource matching service[chef-client] (did you define it first?)
```
