### PR TITLE
Add 2nd url to public_info for redundancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of rackops_rolebook.
 
+## 3.1.4
+# Added public_info resilience
+
 ## 3.0.3
 * Added the range 92.52.126.0/24 of RS pollers to acl.rb - the absense of this range causes alerts
 

--- a/files/default/public_info.rb
+++ b/files/default/public_info.rb
@@ -23,13 +23,18 @@ Ohai.plugin(:Publicinfo) do
 
   collect_data(:linux) do
     url = 'http://whoami.rackops.org/api'
-    response = RestClient.get(url)
+    # Handle errors and no response for whoami.rackops.org
+    begin
+      response = RestClient.get(url)
+    rescue
+      response = RestClient.get('http://dazzlepod.com/ip/me.json')
+    end
     results = JSON.parse(response)
     if results.nil?
-      Ohai::Log.debug('Failed to return info from whoami.rackops.org')
+      Ohai::Log.debug('Failed to return Public_info results')
     else
       public_info Mash.new
-      public_info[:remote_ip] = results['remote_ip']
+      public_info[:remote_ip] = results.key?('remote_ip') ? results['remote_ip'] : results['ip']
       public_info[:X_Forwarded] = results['X_Forwarded']
       public_info[:asn] = results['asn']
       public_info[:city] = results['city']

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'All rights reserved'
 description      'Installs/Configures rackops_rolebook'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version          '3.1.3'
+version          '3.1.4'
 
 depends 'apt', '>= 2.4'
 depends 'git'


### PR DESCRIPTION
Public_info will now try http://whoami.rackops.org/api first and if this fails it will use http://dazzlepod.com/ip/me.json. There is a difference in the JSON returned for remote_ip from dazzlepod so logic added to deal with this. 
