### PR TITLE
Move rest-client requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of rackops_rolebook.
 
+## 3.1.5
+# Ensure we install rest-client gem since public_info requires it
+
 ## 3.1.4
 # Added public_info resilience
 

--- a/files/default/public_info.rb
+++ b/files/default/public_info.rb
@@ -16,12 +16,12 @@
 # limitations under the License.
 
 require 'json'
-require 'rest-client'
 
 Ohai.plugin(:Publicinfo) do
   provides 'public_info'
 
   collect_data(:linux) do
+    require 'rest-client'
     url = 'http://whoami.rackops.org/api'
     # Handle errors and no response for whoami.rackops.org
     begin

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'All rights reserved'
 description      'Installs/Configures rackops_rolebook'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version          '3.1.4'
+version          '3.1.5'
 
 depends 'apt', '>= 2.4'
 depends 'git'
@@ -15,3 +15,4 @@ depends 'platformstack', '>= 0.1.1'
 depends 'rackspace_iptables', '>= 1.2'
 depends 'sudo', '>= 2.6'
 depends 'user', '>= 0.3'
+depends 'chef-sugar'

--- a/recipes/public_info.rb
+++ b/recipes/public_info.rb
@@ -6,13 +6,19 @@
 #
 # Copyright 2014, Rackspace, US Inc.
 #
+include_recipe 'chef-sugar'
+
+# ensure rest-client gem is available
+rest_client_gem = chef_gem 'rest-client' do
+  action :nothing
+end.run_action('install')
 
 # Load the ohai recipe to populate node['ohai']
 include_recipe 'ohai'
 
 # Fail in a slightly more descriptive manner than the directory block below
 #  if the plugin directory is unset.
-if node['ohai']['plugin_path'].nil?
+if node['ohai'] && node['ohai']['plugin_path'].nil?
   fail 'ERROR: Ohai plugin path not set'
 end
 
@@ -40,7 +46,7 @@ end.run_action('reload')
 # Stop the run if the IP is invalid, assume failure here is preferable to running with invalid data
 # This check is also important for testing: if the plugin fails to load and operate this exception will
 #  halt convergance breaking Kitchen runs.
-unless node['public_info']['remote_ip'] =~ /[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/
+unless node.deep_fetch('public_info', 'remote_ip') =~ /[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/
   fail "ERROR: Unable to determine server remote IP. (Got \"#{node['public_info']['remote_ip']}\") Halting to avoid use of bad data."
 end
 


### PR DESCRIPTION
We should require rest-client at runtime, not load time. We should also install the gem if public_info depends on it (it does).

RE: https://github.com/rackops/rackops_rolebook/issues/43
